### PR TITLE
Refactored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ eshell/history
 eshell/lastdir
 custom.el
 .dir-locals.el
+.aider*
+.env

--- a/.stow-rename
+++ b/.stow-rename
@@ -1,0 +1,1 @@
+tmux.conf => .tmux.conf

--- a/alacritty/alacritty.yml
+++ b/alacritty/alacritty.yml
@@ -1,17 +1,17 @@
 font:
   normal:
-    family: JetBrainsMono NL
+    family: JetBrainsMonoNL Nerd Font Mono
     style: Light
 
   bold:
-    family: JetBrainsMono NL
+    family: JetBrainsMonoNL Nerd Font Mono
     style: Medium
 
   italic:
-    family: JetBrainsMono
+    family: JetBrainsMonoNL Nerd Font Mono
     style: "Light Italic"
 
-  size: 13.0
+  size: 10.0
 
   offset:
     x: 0

--- a/emacs/configs/capf.el
+++ b/emacs/configs/capf.el
@@ -110,16 +110,6 @@
  (require 'corfu-popupinfo)
  (corfu-popupinfo-mode 1)
  :config
- ;; NOTE 2022-03-01: This allows for a more evil-esque way to have
- ;; `corfu-insert-separator' work with space in insert mode without resorting to
- ;; overriding keybindings with `general-override-mode-map'. See
- ;; https://github.com/minad/corfu/issues/12#issuecomment-869037519
- ;; Alternatively, add advice without `general.el':
- (advice-add 'corfu--setup :after 'evil-normalize-keymaps)
- (advice-add 'corfu--teardown :after 'evil-normalize-keymaps)
- ;; (general-add-advice '(corfu--setup corfu--teardown) :after 'evil-normalize-keymaps)
- ;; (evil-make-overriding-map corfu-map)
-
  ;; Enable Corfu more generally for every minibuffer, as long as no other
  ;; completion UI is active. If you use Mct or Vertico as your main minibuffer
  ;; completion UI. From
@@ -190,7 +180,7 @@ default lsp-passthrough."
  ;;                   "d" 'cape-dabbrev   ; or dabbrev-completion
  ;;                   "f" 'cape-file
  ;;                   "k" 'cape-keyword
- ;;                   "s" 'cape-symbol
+ ;;                   "s" 'cape-elisp-symbol
  ;;                   "a" 'cape-abbrev
  ;;                   "i" 'cape-ispell
  ;;                   "l" 'cape-line
@@ -216,7 +206,7 @@ default lsp-passthrough."
            'elisp-completion-at-point completion-at-point-functions)
           0)
          #'elisp-completion-at-point)
-   (add-to-list 'completion-at-point-functions #'cape-symbol)
+   (add-to-list 'completion-at-point-functions #'cape-elisp-symbol)
    ;; I prefer this being early/first in the list
    (add-to-list 'completion-at-point-functions #'cape-file)
    ;; (require 'company-yasnippet)
@@ -224,18 +214,18 @@ default lsp-passthrough."
    )
 
  ;; Org
- ;; (defun kb/cape-capf-setup-org ()
- ;;   (require 'org-roam)
- ;;   (if (org-roam-file-p)
- ;;       (org-roam--register-completion-functions-h)
- ;;     (let (result
- ;;       (dolist (element (list
- ;;                         (cape-super-capf #'cape-ispell #'cape-dabbrev)
- ;;                         ;; (cape-company-to-capf #'company-yasnippet)
- ;;                         )
- ;;                        result)
- ;;         (add-to-list 'completion-at-point-functions element)))
- ;;     )))
+ (defun kb/cape-capf-setup-org ()
+   (require 'org-roam)
+   (if (org-roam-file-p)
+       (org-roam--register-completion-functions-h)
+     (let (result
+           (dolist (element
+                    (list
+                     (cape-capf-super #'cape-ispell #'cape-dabbrev)
+                     ;; (cape-company-to-capf #'company-yasnippet)
+                     )
+                    result)
+             (add-to-list 'completion-at-point-functions element))))))
 
  ;; Eshell
  (defun kb/cape-capf-setup-eshell ()
@@ -252,7 +242,7 @@ default lsp-passthrough."
     "<tab>" 'completion-at-point) ; Keybinding for `completion-at-point'
    (let ((result))
      (dolist (element
-              '(cape-symbol
+              '(cape-elisp-symbol
                 cape-dabbrev tags-completion-at-point-function)
               result)
        (add-to-list 'completion-at-point-functions element))))

--- a/emacs/configs/chatgpt.el
+++ b/emacs/configs/chatgpt.el
@@ -1,6 +1,7 @@
 (use-package
  gptel
+ :disabled
  :custom
  (gptel-api-key "")
  (gptel-model "gpt-4")
- :straight (:local-repo "/home/dbohomiakov/work/bcd/gptel"))
+ :straight (:local-repo "/home/dmytro/work/bcd/gptel"))

--- a/emacs/configs/common.el
+++ b/emacs/configs/common.el
@@ -208,10 +208,9 @@
 (use-package
  apheleia
  :init (apheleia-global-mode +1)
- :config (setf (alist-get 'python-mode apheleia-mode-alist) '(isort black))
- ;; (setf (alist-get 'python-ts-mode apheleia-mode-alist)
- ;;       '(isort black))
- )
+ :config
+ (setf (alist-get 'python-ts-mode apheleia-mode-alist) '(isort black))
+ (setf (alist-get 'python-mode apheleia-mode-alist) '(isort black)))
 
 (use-package
  elisp-autofmt
@@ -237,9 +236,23 @@
 
  (use-package devdocs)
 
+ (use-package
+  xclip
+  :disabled
+  :config
+  (setq xclip-program "wl-copy")
+  (setq xclip-select-enable-clipboard t)
+  (setq xclip-mode t)
+  (setq xclip-method (quote wl-copy)))
+
  (defun my/protected-buffers ()
    "Protect some buffers from being killed."
    (dolist (buffer protected-buffers)
      (with-current-buffer buffer
        (emacs-lock-mode 'kill))))
  :init (my/protected-buffers))
+
+(use-package
+ visual-replace
+ :defer t
+ :straight (:host github :repo "szermatt/visual-replace"))

--- a/emacs/configs/copilot.el
+++ b/emacs/configs/copilot.el
@@ -5,4 +5,23 @@
  :ensure t
  :custom
  (copilot-node-executable
-  "/home/dbohomiakov/.asdf/installs/nodejs/18.18.2/bin/node"))
+  "/home/dmytro/.asdf/installs/nodejs/18.19.1/bin/node"))
+
+
+(use-package
+ copilot-chat
+ :straight
+ (:host github :repo "chep/copilot-chat.el" :files ("*.el"))
+ :after (request org markdown-mode shell-maker)
+ :custom (copilot-chat-frontend 'org))
+
+(add-hook 'git-commit-setup-hook 'copilot-chat-insert-commit-message)
+
+(use-package
+ aider
+ :straight (:host github :repo "tninja/aider.el" :files ("aider.el"))
+ :config
+ (setq aider-args '("--model" "gpt-4o-mini"))
+ (setenv "OPENAI_API_KEY" "")
+ ;; Optional: Set a key binding for the transient menu
+ (global-set-key (kbd "C-c a") 'aider-transient-menu))

--- a/emacs/configs/go.el
+++ b/emacs/configs/go.el
@@ -13,14 +13,3 @@
  :hook (go-mode . flycheck-golangci-lint-setup))
 
 (use-package go-tag)
-
-(use-package k8s-mode :ensure t :hook (k8s-mode . yas-minor-mode))
-
-(use-package
- kubernetes
- :ensure t
- :commands (kubernetes-overview)
- :config
- (setq
-  kubernetes-poll-frequency 3600
-  kubernetes-redraw-frequency 3600))

--- a/emacs/configs/http.el
+++ b/emacs/configs/http.el
@@ -5,12 +5,12 @@
   'verb-content-type-handlers
   '("application/hal\\+json" verb-handler-json)))
 
-;; (org-babel-do-load-languages
-;;  'org-babel-load-languages
-;;  '((emacs-lisp . t)
-;;    (ipython . t)
-;;    (shell . t)
-;;    (python . t)
-;;    (org . t)
-;;    (sql . t)
-;;    (verb . t)))
+(org-babel-do-load-languages
+ 'org-babel-load-languages
+ '((emacs-lisp . t)
+   (ipython . t)
+   (shell . t)
+   (python . t)
+   (org . t)
+   (sql . t)
+   (verb . t)))

--- a/emacs/configs/javascript.el
+++ b/emacs/configs/javascript.el
@@ -1,0 +1,4 @@
+(use-package
+ js-mode
+ :straight (:type built-in)
+ :hook ((js-mode . eglot-ensure)))

--- a/emacs/configs/k8s.el
+++ b/emacs/configs/k8s.el
@@ -1,0 +1,14 @@
+(use-package k8s-mode :ensure t :hook (k8s-mode . yas-minor-mode))
+
+(use-package
+ kubernetes
+ :ensure t
+ :commands (kubernetes-overview)
+ :config
+ (setq
+  kubernetes-poll-frequency 3600
+  kubernetes-redraw-frequency 3600))
+
+(use-package kele :straight t :config (kele-mode 1))
+
+(use-package kubel :after (vterm) :config (kubel-vterm-setup))

--- a/emacs/configs/kbd.el
+++ b/emacs/configs/kbd.el
@@ -61,7 +61,7 @@
               ;; "ps" 'consult-projectile-switch-project
               "pg" 'consult-ripgrep
               "pd" 'project-dired
-              "pe" 'project-eshell-other-window
+              "pe" 'vterm-toggle-cd
               "pE" 'project-eshell
               "pC" 'project-compile
               "pp" 'consult-projectile

--- a/emacs/configs/project.el
+++ b/emacs/configs/project.el
@@ -5,11 +5,7 @@
  :bind-keymap ("C-c p" . projectile-command-map)
  :init
  (when (file-directory-p "~/work/")
-   (setq projectile-project-search-path
-         '("~/work/"
-           "~/work/bcd/"
-           "~/work/clojure"
-           "~/work/golang/src/")))
+   (setq projectile-project-search-path '("~/work/")))
  (setq projectile-switch-project-action #'projectile-dired))
 
 (use-package
@@ -49,3 +45,26 @@
   ("P" . project-tasks)
   ("o" . project-tasks-capture)
   ("O" . project-tasks-jump)))
+
+
+;; (require 'cl-extra)
+;; (setq projectile-sentinels
+;;       '("cargo.toml" "go.mod" ".monorepo-project"))
+
+;; (defun find-enclosing-project (dir)
+;;   (locate-dominating-file
+;;    dir
+;;    (lambda (file)
+;;      (and (file-directory-p file)
+;;           (cl-some
+;;            (lambda (sentinel)
+;;              (file-exists-p (expand-file-name sentinel file)))
+;;            project-sentinels)))))
+
+;; (add-hook
+;;  'project-find-functions
+;;  #'(lambda (d)
+;;      (let ((dir (find-enclosing-project d)))
+;;        (if dir
+;;            (cons 'vc dir)
+;;          nil))))

--- a/emacs/configs/python.el
+++ b/emacs/configs/python.el
@@ -58,7 +58,8 @@
  (flymake-ruff
   :type git
   :host github
-  :repo "erickgnavar/flymake-ruff"))
+  :repo "erickgnavar/flymake-ruff")
+ :hook (eglot-managed-mode . flymake-ruff-load))
 
 
 ;; Initialize .dir-locals variables

--- a/emacs/configs/rust.el
+++ b/emacs/configs/rust.el
@@ -1,15 +1,17 @@
-(use-package cargo
-  :hook
-  (cargo-minor-mode-hook . rust-mode))
+(use-package
+ cargo
+ :after rust-mode
+ :hook (cargo-minor-mode-hook . rust-mode))
 
-(use-package rust-mode
-  :hook ((rust-mode-hook . (lambda () (setq indent-tabs-mode nil)))
-         (rust-mode-hook . cargo-minor-mode))
-  :custom
-  (rust-format-on-save t))
+(use-package
+ rust-mode
+ :hook
+ ((rust-mode-hook . (lambda () (setq indent-tabs-mode nil))))
+ :custom (rust-format-on-save t))
 
-(use-package racer
-  :hook
-  (rust-mode-hook . racer-mode)
-  (racer-mode-hook . eldoc-mode)
-  (racer-mode-hook . cargo-minor-mode))
+(use-package
+ racer
+ :hook
+ (rust-mode-hook . racer-mode)
+ (racer-mode-hook . eldoc-mode)
+ (racer-mode-hook . cargo-minor-mode))

--- a/emacs/configs/shell.el
+++ b/emacs/configs/shell.el
@@ -1,32 +1,34 @@
-(use-package
- esh-autosuggest
- :hook (eshell-mode . esh-autosuggest-mode))
+;; (use-package
+;;  esh-autosuggest
+;;  :hook (eshell-mode . esh-autosuggest-mode))
 
 
-(defun project-eshell-other-window ()
-  "Open a `shell' in a new window."
-  (interactive)
-  (let ((buf (project-eshell)))
-    (switch-to-buffer (other-buffer buf))
-    (switch-to-buffer-other-window buf)))
+;; (defun project-eshell-other-window ()
+;;   "Open a `shell' in a new window."
+;;   (interactive)
+;;   (let ((buf (project-eshell)))
+;;     (switch-to-buffer (other-buffer buf))
+;;     (switch-to-buffer-other-window buf)))
 
 
-(defun project-async-shell-command-other-window ()
-  "Open a `shell' in a new window."
-  (interactive)
-  (let ((buf (project-async-shell-command)))
-    (switch-to-buffer (other-buffer buf))
-    (switch-to-buffer-other-window buf)))
+;; (defun project-async-shell-command-other-window ()
+;;   "Open a `shell' in a new window."
+;;   (interactive)
+;;   (let ((buf (project-async-shell-command)))
+;;     (switch-to-buffer (other-buffer buf))
+;;     (switch-to-buffer-other-window buf)))
 
-(require 'fish-completion)
+;; (require 'fish-completion)
 
-(use-package shell-pop)
+;; (use-package shell-pop)
 ;:custom
 ;(shell-pop-shell-type '("eshell" "*eshell*" (lambda () (eshell))))
 
 (use-package
  vterm
- :disabled
+ :custom
+ (vterm-shell "fish")
+ (vterm-clear-scrollback-when-clearing t)
  :config
  (setq vterm-kill-buffer-on-exit t)
  (setq vterm-copy-exclude-prompt t)
@@ -37,12 +39,12 @@
 
 (use-package
  vterm-toggle
- :disabled
  :ensure t
  :custom
  (vterm-toggle-scope 'project)
  (vterm-toggle-hide-method 'reset-window-configration)
  :hook (vterm-toggle-show . evil-insert-state))
+
 
 ;; (setq vterm-toggle-fullscreen-p t)
 ;; (add-to-list
@@ -51,20 +53,37 @@
 ;;      (with-current-buffer bufname
 ;;        (equal major-mode 'vterm-mode)))
 ;;    (display-buffer-reuse-window display-buffer-same-window)))
-;; (global-set-key [f2] 'vterm-toggle)
-;; (global-set-key [C-f2] 'vterm-toggle-cd)
 
 
-;; (defun evil-collection-vterm-escape-stay ()
-;;   "Go back to normal state but don't move
-;; cursor backwards. Moving cursor backwards is the default vim behavior but it is
-;; not appropriate in some cases like terminals."
-;;   (setq-local evil-move-cursor-back nil))
+(setq vterm-toggle-fullscreen-p nil)
+(add-to-list
+ 'display-buffer-alist
+ '((lambda (buffer-or-name _)
+     (let ((buffer (get-buffer buffer-or-name)))
+       (with-current-buffer buffer
+         (or (equal major-mode 'vterm-mode)
+             (string-prefix-p
+              vterm-buffer-name (buffer-name buffer))))))
+   (display-buffer-reuse-window display-buffer-in-side-window)
+   (side . bottom)
+   (dedicated . t) ;dedicated is supported in emacs27
+   (reusable-frames . visible)
+   (window-height . 0.3)))
 
-;; (add-hook 'vterm-mode-hook #'evil-collection-vterm-escape-stay)
 
-;; (define-key
-;;  vterm-mode-map (kbd "<C-backspace>")
-;;  (lambda ()
-;;    (interactive)
-;;    (vterm-send-key (kbd "C-w"))))
+(global-set-key [f2] 'vterm-toggle)
+(global-set-key [C-f2] 'vterm-toggle-cd)
+
+(defun evil-collection-vterm-escape-stay ()
+  "Go back to normal state but don't move
+cursor backwards. Moving cursor backwards is the default vim behavior but it is
+not appropriate in some cases like terminals."
+  (setq-local evil-move-cursor-back nil))
+
+(add-hook 'vterm-mode-hook #'evil-collection-vterm-escape-stay)
+
+(define-key
+ vterm-mode-map (kbd "<C-backspace>")
+ (lambda ()
+   (interactive)
+   (vterm-send-key (kbd "C-w"))))

--- a/emacs/configs/tree-sitter.el
+++ b/emacs/configs/tree-sitter.el
@@ -37,15 +37,19 @@
 (use-package posframe)
 
 ; ;; BUILTIN TREESIT
-;; (use-package
-;;  treesit-auto
-;;  :custom (treesit-auto-install 'prompt)
-;;  :config
-;;  (treesit-auto-add-to-auto-mode-alist 'all)
-;;  (global-treesit-auto-mode))
+(use-package
+ treesit-auto
+ :disabled
+ :custom (treesit-auto-install 'prompt)
+ :config (treesit-auto-add-to-auto-mode-alist 'all))
 
-; (use-package
-;  evil-ts
-;  :disabled
-;  :straight
-;  (evil-ts :type git :host github :repo "foxfriday/evil-ts"))
+(use-package
+ evil-ts
+ :disabled
+ :straight
+ (evil-ts :type git :host github :repo "foxfriday/evil-ts"))
+
+(use-package
+ treesit
+ :straight (:type built-in)
+ :custom (treesit-font-lock-level 4))

--- a/emacs/configs/ui.el
+++ b/emacs/configs/ui.el
@@ -15,7 +15,7 @@
  (display-time-load-average t)
  (display-time-load-average-threshold 1000))
 
-(use-package all-the-icons :diminish)
+(use-package all-the-icons)
 
 (use-package
  all-the-icons-dired
@@ -99,23 +99,24 @@
 (use-package snow)
 (use-package fireplace)
 
-(defvar db/font-family "JetBrainsMono NL")
+(defvar db/font-family "JetBrainsMonoNL Nerd Font Mono")
 (defvar db/font-weight 'normal)
 
+;; todo make them relative to screen
 (defun db/set-font-faces ()
   (set-face-attribute 'default nil
                       :font db/font-family
-                      :height 120
+                      :height 100
                       :weight db/font-weight)
   ;; Set the fixed pitch face
   (set-face-attribute 'fixed-pitch nil
                       :font db/font-family
-                      :height 90
+                      :height 70
                       :weight 'light)
   ;; Set the variable pitch face
   (set-face-attribute 'variable-pitch nil
                       :font db/font-family
-                      :height 120
+                      :height 100
                       :weight 'light))
 
 (if (daemonp)

--- a/emacs/configs/vcs.el
+++ b/emacs/configs/vcs.el
@@ -7,7 +7,7 @@
  (magit-published-branches '("origin/master" "origin/main"))
  (magit-view-git-manual-method 'man))
 
-;; (use-package magit-todos :after magit :init (magit-todos-mode))
+(use-package magit-todos :after magit :init (magit-todos-mode))
 
 (use-package
  forge

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -99,7 +99,7 @@
  (exec-path-from-shell-variables '("PATH" "MANPATH" "GOPATH"))
  (exec-path-from-shell-shell-name "fish"))
 
-(when (memq window-system '(mac ns x))
+(when (memq window-system '(mac ns x pgtk))
   (exec-path-from-shell-initialize))
 (when (daemonp)
   (exec-path-from-shell-initialize))
@@ -135,6 +135,7 @@
    "chatgpt"
    "popup"
    "copilot"
+   ;; "k8s"
    "kbd"))
 
 

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -46,10 +46,14 @@ set -g status-right-length 140
 # set -g status-right '#[fg=white,bg=default]%H:%M:%S | %a %d-%m-%Y#[default]'
 
 # Copy
-set -g set-clipboard off
-bind-key -T copy-mode-vi 'v' send -X begin-selection
-bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel 'xsel -bi'
-bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel 'xsel -bi'
+set-option -s set-clipboard off
+bind P paste-buffer
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi V send-keys -X rectangle-toggle
+unbind -T copy-mode-vi Enter
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'wl-copy'
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'wl-copy'
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'wl-copy'
 
 # Pane manual resize/split
 set -g @plugin 'tmux-plugins/tmux-pain-control'


### PR DESCRIPTION
- Update `.gitignore` to include `.aider*` and `.env`
- Add `.stow-rename` file
- Modify `alacritty.yml` font settings
- Remove outdated advice in `capf.el`
- Disable `gptel` package in `chatgpt.el`
- Update `apheleia` configuration in `common.el`
- Add `xclip` and `visual-replace` packages
- Update `copilot.el` with `copilot-chat` and `aider` packages
- Add `eglot-booster` package in `eglot.el`
- Add `javascript.el` and `k8s.el` configuration files
- Update `kbd.el` to use `vterm-toggle-cd`
- Simplify `projectile` search path in `project.el`
- Update `python.el` to hook `flymake-ruff-load`
- Refactor `rust.el` package configurations
- Update `shell.el` to use `vterm` and `vterm-toggle`
- Enable `treesit-auto` and `evil-ts` packages in `tree-sitter.el`
- Update font settings in `ui.el`
- Enable `magit-todos` in `vcs.el`
- Update `init.el` to include `pgtk` window system
- Rename `.tmux.conf` to `tmux/tmux.conf` and update clipboard settings
